### PR TITLE
Handle cases where app name and package name are inconsistent

### DIFF
--- a/lib/changelog/cli.ex
+++ b/lib/changelog/cli.ex
@@ -83,8 +83,9 @@ defmodule Changelog.CLI do
     for {_, package} <- packages, into: %{} do
       case :hex_api_package.get(hex_config, package) do
         {:ok,
-         {_status, _headers, %{"latest_version" => latest_version, "meta" => %{"links" => links}}}} ->
-          {package, %{latest_version: latest_version, changelog: fetch_changelog(links)}}
+         {_status, _headers,
+          %{"latest_stable_version" => latest_stable_version, "meta" => %{"links" => links}}}} ->
+          {package, %{latest_version: latest_stable_version, changelog: fetch_changelog(links)}}
 
         _ ->
           {package, %{}}


### PR DESCRIPTION
One of my projects had a transitive dependency on the [new_gollum](https://hex.pm/packages/new_gollum) package. new_gollum's `mix.exs` defines its package name as [`new_gollum`](https://github.com/elixir-crawly/gollum/blob/master/mix.exs#L36) but its app name is [`gollum`](https://github.com/elixir-crawly/gollum/blob/master/mix.exs#L6). When this package is used in a project, the `mix.lock` file is key'ed with `gollum` and not `new_gollum`. Because changelog was doing a simple `Map.get` to find the package to get the version, I was getting a crash when the iteration got to the `new_gollum` package. This pull request address that problem by first attempting to do a lookup using the key, but falling back on a search of the lock file for a package with that app name. I've also added an error that gets raised if both of these strategies fail to find the package so it's more clear as to why changelog is failing.

This isn't super robust. Given mix keys off of the app name, it's possible that changeling's lookup will still differ from what Mix is doing as we don't know both the package name and app name within changelog. I figure this is an improvement for now, anyway.

Test plan: see crash when running `mix changelog` prior to this commit. Following the commit, see that it is able to process the entire `mix.lock` file, ensuring that the existing behaviour works as expected.