### PR TITLE
Use latest_stable_version from Hex API for comparing versions

### DIFF
--- a/lib/changelog/cli.ex
+++ b/lib/changelog/cli.ex
@@ -59,8 +59,9 @@ defmodule Changelog.CLI do
     for {_, package} <- packages, into: %{} do
       case :hex_api_package.get(hex_config, package) do
         {:ok,
-         {_status, _headers, %{"latest_version" => latest_version, "meta" => %{"links" => links}}}} ->
-          {package, %{latest_version: latest_version, changelog: fetch_changelog(links)}}
+         {_status, _headers,
+          %{"latest_stable_version" => latest_stable_version, "meta" => %{"links" => links}}}} ->
+          {package, %{latest_version: latest_stable_version, changelog: fetch_changelog(links)}}
 
         _ ->
           {package, %{}}


### PR DESCRIPTION
I've seen some problems with the `postgrex` package, as there were some long-since-retired releases from 2016 that had an increment in major version before the project kept going with `0.` releases. Long story short, `mix changelog` has been prompting to upgrade to these extremely old releases. This pull request moves to using the `latest_stable_release` value from the Hex API which should address this problem, and also ensure that changelog isn't prompting to upgrade to unstable releases like RCs or retired versions. This seems like a reasonable default behaviour, although I'm happy to stick this behind a `--stable` flag or add the old behaviour behind an `--unstable` flag